### PR TITLE
Fix petting lights showing up when not desired

### DIFF
--- a/engine/aiComponent/behaviorComponent/behaviors/victor/behaviorReactToTouchPetting.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/victor/behaviorReactToTouchPetting.cpp
@@ -140,7 +140,9 @@ void BehaviorReactToTouchPetting::AlwaysHandleInScope(const EngineToGameEvent& e
         auto touchTimePress = BaseStationTimer::getInstance()->GetCurrentTimeInSeconds();
         _checkForTransitionTime = touchTimePress + _timeTilTouchCheck;
         _numPressesAtCurrentBlissLevel++;
-        GetBEI().GetBackpackLightComponent().SetBackpackAnimation(BackpackAnimationTrigger::Petting);
+        if (IsActivated()) {
+          GetBEI().GetBackpackLightComponent().SetBackpackAnimation(BackpackAnimationTrigger::Petting);
+        }
       } else {
         auto touchTimeRelease = BaseStationTimer::getInstance()->GetCurrentTimeInSeconds();
         _checkForTimeoutTimeBliss = touchTimeRelease + _blissTimeout;


### PR DESCRIPTION
Addresses this WireOS issue: https://github.com/os-vector/wire-os/issues/48 

Fix was simple, just don't activate the lights if the behavior isn't activated.