### PR TITLE
Changes to how the age finding system works

### DIFF
--- a/engine/aiComponent/behaviorComponent/behaviors/character/howOldAreYou/behaviorHowOldAreYou.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/character/howOldAreYou/behaviorHowOldAreYou.cpp
@@ -132,7 +132,7 @@ void BehaviorHowOldAreYou::OnBehaviorActivated()
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 std::chrono::hours BehaviorHowOldAreYou::GetRobotAge()
 {
-  // This used to use the onboarding completion time for date, when authing the dev bot to wp this gets overwritten so instead use the gateway cert file
+  // This used to use the onboarding completion time for date, when authing the dev bot to wp this gets overwritten so instead use when /data/persist was created
   // check whether onboardingState file exists
   // const auto* platform = GetBEI().GetRobotInfo().GetContext()->GetDataPlatform();
   // _saveFolder = "/data/vic-gateway";
@@ -173,7 +173,7 @@ std::chrono::hours BehaviorHowOldAreYou::GetRobotAge()
 
     // if(!parsed || !containsBoD) {
       // if not we couldn't get born on date from file, use modification time of the file
-      onboardingTime_sse = Util::FileUtils::GetFileLastModificationTime( "/data/vic-gateway/gateway.cert" ); // seconds since the epoch
+      onboardingTime_sse = Util::FileUtils::GetFileLastModificationTime( "/data/persist" ); // seconds since the epoch
       LOG_INFO("BehaviorHowOldAreYou.GetRobotAge.ModificationTimeFallback",
           "Using file modification time of vic-gateway certificate (seconds since epoch): %lld",
           onboardingTime_sse);


### PR DESCRIPTION
- First try to get the age from `/data/persist`
- If the age from `/data/persist` is older than 2016 fall back to the onboarding state file
- If that's still older than 2016 rely on `onboardingState.json`.
- If it doesn't exist just use the stats tracker like the original system did.

This is as far as I can tell, the best way to get the truly accurate date of when the bot was activated.
- WirePod wipes the gateway cert and the onboardingState file so we can't use those to get the accurate date
- And the robot stats tracker only counts how long the bot has been alive for, not it's activation date unless the robot has never been turned off since it's activation date.

There's not really a more accurate way than this _TO MY KNOWLEDGE_ to get the real date of bots that have been authenticated with WirePod.