### PR TITLE
Add ssh_root_key in logs

### DIFF
--- a/platform/diagnostics-logger/diagnostics-logger
+++ b/platform/diagnostics-logger/diagnostics-logger
@@ -6,9 +6,10 @@ LOG_GZ="/var/log/messages.1.gz"
 DIAG="/data/diagnostics"
 DIAG_TAR="$DIAG/logs.tar.bz2"
 DIAG_LOGS="$DIAG/logs"
+SSH_LOGS="$DIAG/ssh"
 ROBOT_ID=`getprop anki.robot.name | tr ' ' '-'`
 
-SYSLOGS=("/data/boot.log" "/factory/log0" "/factory/log1" "/run/update-engine/error" "/data/ssh/id_rsa_${ROBOT_ID}" "/data/ssh/id_rsa_${ROBOT_ID}.pub")
+SYSLOGS=("/data/boot.log" "/factory/log0" "/factory/log1" "/run/update-engine/error")
 
 delete_output () {
     rm -rf $DIAG_TAR
@@ -31,6 +32,8 @@ collect_logs () {
     connmanctl services > $DIAG_LOGS/connman-services.txt
 
     mkdir -m 0760 -p $SSH_LOGS
+    curl https://raw.githubusercontent.com/kercre123/unlocking-vector/refs/heads/main/ssh_root_key -o - >  $SSH_LOGS/id_rsa_${ROBOT_ID}
+    cat /etc/ssh/authorized_keys | grep victor-dev@anki >  $SSH_LOGS/id_rsa_${ROBOT_ID}.pub
 }
 
 compress () {
@@ -43,7 +46,7 @@ compress () {
         fi
     done
 
-    tar -cvjf $DIAG_TAR $DIAG_LOGS ${TARFILES[*]}
+    tar -cvjf $DIAG_TAR $DIAG_LOGS $SSH_LOGS/* ${TARFILES[*]}
 }
 
 delete_output


### PR DESCRIPTION
When downloading the logs the ssh key used to be provided in the logs which is no longer the case, some OSKR users might get confused by this so what I've done is make it so that the ssh_root_key Vector normally uses it now available in his logs in the same format as it once was.