### PR TITLE
Image drawing changes for faultcodedisplay and robot.cpp

### DIFF
--- a/engine/robot.cpp
+++ b/engine/robot.cpp
@@ -2747,6 +2747,12 @@ bool Robot::UpdateGyroCalibChecks(Result& res)
                                                                          kGyroNotCalibratedImg);
     Vision::ImageRGB img;
     img.Load(imgPath);
+
+    // Emily - Ported from 1.6-rebuild: Resize the image on the fly so Vector 2.0 can correctly display it
+    if (img.GetNumCols() != FACE_DISPLAY_WIDTH || img.GetNumRows() != FACE_DISPLAY_HEIGHT) {
+      img.Resize(FACE_DISPLAY_HEIGHT, FACE_DISPLAY_WIDTH);
+    }
+
     // Display the image indefinitely or atleast until something else is displayed
     GetAnimationComponent().DisplayFaceImage(img, 0, true);
     // Move the head to look up to show the image clearly

--- a/platform/faultCodeDisplay/faultCodeDisplay.cpp
+++ b/platform/faultCodeDisplay/faultCodeDisplay.cpp
@@ -10,6 +10,7 @@
 **/
 
 #include "anki/cozmo/shared/cozmoConfig.h"
+#include "anki/cozmo/shared/factory/faultCodes.h"
 #include "core/lcd.h"
 #include "coretech/vision/engine/image.h"
 #include "opencv2/highgui.hpp"
@@ -32,6 +33,12 @@ static const std::unordered_map<uint16_t,std::string> kFaultText = {
   {914,  "vic-engine crashed."},
   {980,  "Camera issue (980)."},
   {981,  "Camera process issue (981)."},
+};
+
+// Map of fault codes that map to images that should be drawn instead of the number
+std::unordered_map<uint16_t, std::string> kFaultImageMap = {
+  {FaultCode::SHUTDOWN_BATTERY_CRITICAL_TEMP, "/anki/data/assets/cozmo_resources/config/sprites/independentSprites/battery_overheated.png"},
+  {FaultCode::SHUTDOWN_BATTERY_CRITICAL_VOLT, "/anki/data/assets/cozmo_resources/config/sprites/independentSprites/battery_low.png"},
 };
 
 static const char* kSupportURL        = "error.pvic.xyz";
@@ -147,6 +154,21 @@ static void DrawNumber(uint16_t code, bool willRestart)
                   img565.GetNumRows() * img565.GetNumCols() * sizeof(u16));
 }
 
+bool DrawImage(std::string& image_path)
+{
+  Vision::ImageRGB565 img565;
+  if (img565.Load(image_path) != RESULT_OK) {
+    return false;
+  }
+
+  // Resize if the image isn't the right size
+  if (img565.GetNumCols() != FACE_DISPLAY_WIDTH || img565.GetNumRows() != FACE_DISPLAY_HEIGHT) {
+    img565.Resize(FACE_DISPLAY_HEIGHT, FACE_DISPLAY_WIDTH);
+  }
+
+  lcd_draw_frame2(reinterpret_cast<u16*>(img565.GetDataPointer()), img565.GetNumRows() * img565.GetNumCols() * sizeof(u16));
+  return true;
+}
 
 }} // ns
 
@@ -159,6 +181,8 @@ int main(int argc,char*argv[])
   using namespace Anki::Vector;
 
   bool willRestart=false;
+  bool imageDrawn = false;
+
   int opt;
   while((opt=getopt(argc,argv,"hr"))!=-1){
     if(opt=='h'){ usage(stdout); return 0; }
@@ -171,8 +195,21 @@ int main(int argc,char*argv[])
   uint16_t code=static_cast<uint16_t>(v);
 
   lcd_init();
+
   auto it=kFaultText.find(code);
-  if(it!=kFaultText.end()) DrawMultiline(code, it->second, willRestart);
-  else                     DrawNumber(code,willRestart);
+  auto faultImageIt = kFaultImageMap.find(code);
+
+  if (faultImageIt != kFaultImageMap.end()) {
+    imageDrawn = DrawImage(faultImageIt->second);
+  }
+
+  if (!imageDrawn) {
+    if (it!=kFaultText.end()) {
+      DrawMultiline(code, it->second, willRestart);
+    } else {
+      DrawNumber(code,willRestart);
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
Resize image so 2.0 can display gyro not calibrated image correctly, re-add logic to display battery overheated and battery low fault codes

- Add resize function in robot.cpp from 1.6-rebuild so that Vector 2.0 can display the home icon correctly when the gyro can't calibrate
- Re-add DrawImage function to faultCodeDisplay.cpp so that Vector can display battery overheated / battery low image since it's more intuitive then fault codes
- Make some of the logic in faultCodeDisplay.cpp slightly cleaner