### PR TITLE
Small changes + fixes

### DIFF
--- a/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
+++ b/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
@@ -764,9 +764,9 @@ void FaceInfoScreenManager::DrawConfidenceClock(
   drawImg.FillWith( {clearColor.r(), clearColor.g(), clearColor.b()} );
 
   const Point2i center_px = { FACE_DISPLAY_WIDTH / 2, FACE_DISPLAY_HEIGHT / 2 };
-  constexpr int circleRadius_px = 40;
+  int circleRadius_px = IsXray() ? 32 : 40;
   constexpr int innerRadius_px = 5;
-  constexpr int maxBarLen_px = circleRadius_px - innerRadius_px - 4;
+  int maxBarLen_px = circleRadius_px - innerRadius_px - 4;
   constexpr int barWidth_px = 3;
   constexpr float angleFactorA = 0.866f; // cos(30 degrees)
   constexpr float angleFactorB = 0.5f; // sin(30 degrees)

--- a/clad/src/clad/types/animationTrigger.clad
+++ b/clad/src/clad/types/animationTrigger.clad
@@ -544,6 +544,7 @@ enum int_32 AnimationTrigger
   VC_SleepingToListeningLoop,
   VC_SleepingToListeningGetOut,
   VC_IntentNeutral,
+  VolumeLevelMute,
   VolumeLevel1,
   VolumeLevel2,
   VolumeLevel3,

--- a/engine/aiComponent/behaviorComponent/behaviors/knowledgeGraph/behaviorKnowledgeGraphQuestion.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/knowledgeGraph/behaviorKnowledgeGraphQuestion.cpp
@@ -143,27 +143,25 @@ namespace Anki
       // Don't generate ready text for intent graph responses
       if (intentDataPtr == nullptr) {
         // start generating our ready text; if we fail, then we'll simply exit the behavior, and cry :(
-        if (_readyTTSWrapper.SetUtteranceText(readyText, {}))
-        {
-          auto callback = [this]()
-          {
-            // after our getin animation, we can prompt the user to speak
-            _dVars.state = EState::WaitingToStream;
-
-            // Need to loop this forever and we'll just cancel it on our own after a timeout
-            DelegateIfInControl(new ReselectingLoopAnimationAction(AnimationTrigger::KnowledgeGraphListening));
-          };
-
-          // open up streaming after we play our get-in to avoid motor noise
-          DelegateIfInControl(new TriggerLiftSafeAnimationAction(AnimationTrigger::KnowledgeGraphGetIn), callback);
-        }
-        else
-        {
+        if (!_readyTTSWrapper.SetUtteranceText(readyText, {})) {
           PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Failed to generate Ready TTS (%s)", readyText.c_str());
+          return;
         }
       } else {
-        PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Not generating ready text because this is a intent graph request.");
+        PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Not generating TTS as this is a intent graph response");
       }
+
+      auto callback = [this]()
+      {
+        // after our getin animation, we can prompt the user to speak
+        _dVars.state = EState::WaitingToStream;
+
+        // Need to loop this forever and we'll just cancel it on our own after a timeout
+        DelegateIfInControl(new ReselectingLoopAnimationAction(AnimationTrigger::KnowledgeGraphListening));
+      };
+
+      // open up streaming after we play our get-in to avoid motor noise
+      DelegateIfInControl(new TriggerLiftSafeAnimationAction(AnimationTrigger::KnowledgeGraphGetIn), callback);
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/engine/aiComponent/behaviorComponent/behaviors/knowledgeGraph/behaviorKnowledgeGraphQuestion.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/knowledgeGraph/behaviorKnowledgeGraphQuestion.cpp
@@ -137,34 +137,32 @@ namespace Anki
       const auto &localeComponent = robotInfo.GetLocaleComponent();
       std::string readyText = localeComponent.GetString(_iVars.readyStringID);
 
-      // Remove ready for intent graph responses
       UserIntentComponent &uic = GetBehaviorComp<UserIntentComponent>();
       UserIntentPtr intentDataPtr = uic.GetUserIntentIfActive(USER_INTENT(knowledge_response_bypass));
-      if (intentDataPtr != nullptr)
-      {
-        readyText = "";
-      }
 
-      const std::string &readyTextAddr = readyText;
-
-      // start generating our ready text; if we fail, then we'll simply exit the behavior, and cry :(
-      if (_readyTTSWrapper.SetUtteranceText(readyTextAddr, {}))
-      {
-        auto callback = [this]()
+      // Don't generate ready text for intent graph responses
+      if (intentDataPtr == nullptr) {
+        // start generating our ready text; if we fail, then we'll simply exit the behavior, and cry :(
+        if (_readyTTSWrapper.SetUtteranceText(readyText, {}))
         {
-          // after our getin animation, we can prompt the user to speak
-          _dVars.state = EState::WaitingToStream;
+          auto callback = [this]()
+          {
+            // after our getin animation, we can prompt the user to speak
+            _dVars.state = EState::WaitingToStream;
 
-          // Need to loop this forever and we'll just cancel it on our own after a timeout
-          DelegateIfInControl(new ReselectingLoopAnimationAction(AnimationTrigger::KnowledgeGraphListening));
-        };
+            // Need to loop this forever and we'll just cancel it on our own after a timeout
+            DelegateIfInControl(new ReselectingLoopAnimationAction(AnimationTrigger::KnowledgeGraphListening));
+          };
 
-        // open up streaming after we play our get-in to avoid motor noise
-        DelegateIfInControl(new TriggerLiftSafeAnimationAction(AnimationTrigger::KnowledgeGraphGetIn), callback);
-      }
-      else
-      {
-        PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Failed to generate Ready TTS (%s)", readyTextAddr.c_str());
+          // open up streaming after we play our get-in to avoid motor noise
+          DelegateIfInControl(new TriggerLiftSafeAnimationAction(AnimationTrigger::KnowledgeGraphGetIn), callback);
+        }
+        else
+        {
+          PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Failed to generate Ready TTS (%s)", readyText.c_str());
+        }
+      } else {
+        PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Not generating ready text because this is a intent graph request.");
       }
     }
 
@@ -219,19 +217,24 @@ namespace Anki
         // at this point our get in animation is complete, so as soon as the audio is finished playing we can transition in
         else if (EState::WaitingToStream == _dVars.state)
         {
-          // once we've finished speaking our ready text, we can start streaming
-          // hopefully the ready text is already finished by the time we even get into this state
-          if (_readyTTSWrapper.IsFinished())
-          {
+          // Not checking for ready text completion for intent graph since we don't play it.
+          if (intentDataPtr != nullptr) {
             BeginStreamingQuestion();
-          }
-          else if (!_readyTTSWrapper.IsValid())
-          {
-            PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Ready prompt TTS failed to play, not cool man");
+          } else {
+            // once we've finished speaking our ready text, we can start streaming
+            // hopefully the ready text is already finished by the time we even get into this state
+            if (_readyTTSWrapper.IsFinished())
+            {
+              BeginStreamingQuestion();
+            }
+            else if (!_readyTTSWrapper.IsValid())
+            {
+              PRINT_NAMED_WARNING("BehaviorKnowledgeGraphQuestion", "Ready prompt TTS failed to play, not cool man");
 
-            // we need to bail, luckily TransitionToNoResponse() handles this exact transition for us
-            CancelDelegates(false);
-            TransitionToNoResponse();
+              // we need to bail, luckily TransitionToNoResponse() handles this exact transition for us
+              CancelDelegates(false);
+              TransitionToNoResponse();
+            }
           }
         }
         // if we're recording the user's question, we need to be listening for a response

--- a/engine/aiComponent/behaviorComponent/behaviors/volume/behaviorVolume.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/volume/behaviorVolume.cpp
@@ -38,7 +38,8 @@ namespace {
   // in the app and in verbal semantics.
   // update: this interface is a moving target. now changed to VOLUME_1 through VOLUME_5...
   // (once it's stabilized we could remove the older ones...)
-  const std::map<std::string, EVolumeLevel> kVolumeLevelMap {//{"mute", EVolumeLevel::MUTE}, // don't ever actually use "mute"
+  const std::map<std::string, EVolumeLevel> kVolumeLevelMap {{"mute", EVolumeLevel::MUTE}, // don't ever actually use "mute" // TOO FUCKING BAD ANKI, I WILL
+                                                            {"VOLUME_0", EVolumeLevel::MUTE},
                                                             {"minimum", EVolumeLevel::MIN},
                                                             {"min", EVolumeLevel::MIN},
                                                             {"VOLUME_1", EVolumeLevel::MIN},
@@ -231,7 +232,7 @@ bool BehaviorVolume::SetVolume(EVolumeLevel desiredVolumeEnum)
 {
   // Let's do some range checking here
   // should really be unnecessary now that we're using the enum, but let's be safe
-  if ( (desiredVolumeEnum < EVolumeLevel::MIN) || (desiredVolumeEnum > EVolumeLevel::MAX) ) {
+  if ( (desiredVolumeEnum < EVolumeLevel::MUTE) || (desiredVolumeEnum > EVolumeLevel::MAX) ) {
     LOG_WARNING("BehaviorVolume.SetVolume.OutsidePermittedRange",
                 "Requested volume %u outside permitted range of [%u,%u].", static_cast<uint32_t>(desiredVolumeEnum), static_cast<uint32_t>(EVolumeLevel::MIN), static_cast<uint32_t>(EVolumeLevel::MAX));
     return false;
@@ -297,7 +298,7 @@ EVolumeLevel BehaviorVolume::ComputeDesiredVolumeFromIncrement(bool positiveIncr
   // read volume from settings
   SettingsManager& settings = GetBEI().GetSettingsManager();
   uint32_t vol = settings.GetRobotSettingAsUInt(external_interface::RobotSetting::master_volume);
-  if ( (vol < static_cast<uint32_t>(EVolumeLevel::MIN) ) || (vol > static_cast<uint32_t>(EVolumeLevel::MAX)) ){
+  if ( (vol < static_cast<uint32_t>(EVolumeLevel::MUTE) ) || (vol > static_cast<uint32_t>(EVolumeLevel::MAX)) ){
     LOG_WARNING("BehaviorVolume.ComputeDesiredVolumeFromIncrement.unexpectedCurrentVolume",
                 "Volume read from settings was outside expected range: %u", vol);
     if (vol < 1 && !positiveIncrement){
@@ -311,8 +312,8 @@ EVolumeLevel BehaviorVolume::ComputeDesiredVolumeFromIncrement(bool positiveIncr
   int increment = positiveIncrement ? 1 : -1;
   uint32_t newVol = vol + increment; 
   // check bounds
-  if (newVol < static_cast<uint32_t>(EVolumeLevel::MIN) ) {
-    newVol = static_cast<uint32_t>(EVolumeLevel::MIN);
+  if (newVol < static_cast<uint32_t>(EVolumeLevel::MUTE) ) {
+    newVol = static_cast<uint32_t>(EVolumeLevel::MUTE);
     LOG_INFO("BehaviorVolume.ComputeDesiredVolumeFromIncrement.out_of_range",
               "volume is already at minimum level");
   }

--- a/engine/aiComponent/behaviorComponent/behaviors/volume/behaviorVolume.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/volume/behaviorVolume.cpp
@@ -52,7 +52,8 @@ namespace {
                                                             {"maximum", EVolumeLevel::MAX},
                                                             {"max", EVolumeLevel::MAX},
                                                             {"VOLUME_5", EVolumeLevel::MAX}};
-  const std::map<EVolumeLevel, AnimationTrigger> kVolumeLevelAnimMap {{EVolumeLevel::MIN, AnimationTrigger::VolumeLevel1},
+  const std::map<EVolumeLevel, AnimationTrigger> kVolumeLevelAnimMap {{EVolumeLevel::MUTE, AnimationTrigger::VolumeLevelMute},
+                                                                    {EVolumeLevel::MIN, AnimationTrigger::VolumeLevel1},
                                                                     {EVolumeLevel::MEDLOW, AnimationTrigger::VolumeLevel2},
                                                                     {EVolumeLevel::MED, AnimationTrigger::VolumeLevel3},
                                                                     {EVolumeLevel::MEDHIGH, AnimationTrigger::VolumeLevel4},

--- a/resources/assets/cladToFileMaps/AnimationTriggerMap.json
+++ b/resources/assets/cladToFileMaps/AnimationTriggerMap.json
@@ -1975,6 +1975,10 @@
     "AnimName": "ag_wakeword_groggyeyes_getout"
   },
   {
+    "CladEvent": "VolumeLevelMute",
+    "AnimName": "ag_volume_stage_min"
+  },
+  {
     "CladEvent": "VolumeLevel1",
     "AnimName": "ag_volume_stage_01"
   },


### PR DESCRIPTION
Couple of small changes + fixes:
- You can now mute Vector by asking (Hey Vector, Volume Mute)
- The size of the circle in the CCIS mic screen on Vector 2.0 is now correctly sized for the 2.0 screen
- Skip attempting to generate the ready text for when Vector is getting a intent graph request.

Reason for the last one is that when Vector has the Japanese tts voice selected it adds a little extra sound at the end of each TTS segment, this happens even if there's just a blank being played. 