### PR TITLE
Fix arm64 macOS compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ vbuild
 <br />
 
 - Prereqs: Make sure you have [brew](https://brew.sh/) installed.
-  -  Then: `brew install ccache wget upx ninja pkg-config`
+  -  Then: `brew install ccache gcc ninja pkg-config upx wget`
 
 1. Clone the repo and cd into it:
 

--- a/project/build-scripts/download-go.sh
+++ b/project/build-scripts/download-go.sh
@@ -13,7 +13,7 @@ ADEPS="$HOME/.anki"
 if [[ "$(uname -a)" == *"x86_64"* && "$(uname -a)" == *"Linux"* ]]; then
     HOST="linux-amd64"
     elif [[ "$(uname -a)" == *"arm64"* && "$(uname -a)" == *"Darwin"* ]]; then
-    HOST="darwin-amd64"
+    HOST="darwin-arm64"
     elif [[ "$(uname -a)" == *"aarch64"* && "$(uname -a)" == *"Linux"* ]]; then
     HOST="linux-arm64"
 else

--- a/project/victor/build-victor.sh
+++ b/project/victor/build-victor.sh
@@ -342,6 +342,8 @@ fi
 HOST=`uname -a | awk '{print tolower($1);}' | sed -e 's/darwin/mac/'`
 if [[ `uname -a` == *"aarch64"* && $HOST == "linux" ]]; then
 	HOST+="-arm64"
+elif [[ `uname -a` == *"aarch64"* && $HOST == "mac" ]]; then
+	HOST+="-arm64"
 fi
 PROTOBUF_HOME=${TOPLEVEL}/3rd/protobuf/${HOST}
 


### PR DESCRIPTION
Makes arm64 macOS work again without needing rosetta.