### PR TITLE
fix(comms): don't tear down the sole client on transient EAGAIN — tri-state Send/Recv contract for LocalUdpServer/Client + callers

### DIFF
--- a/animProcess/src/cozmoAnim/animComms.cpp
+++ b/animProcess/src/cozmoAnim/animComms.cpp
@@ -204,7 +204,23 @@ bool SendPacketToEngine(const void *buffer, const u32 length)
   }
 
   const ssize_t bytesSent = _engineComms.Send((char*)buffer, length);
+  if (bytesSent == 0) {
+    // Would-block (LocalUdpServer::Send tri-state contract): the engine's kernel
+    // receive queue is momentarily full. The datagram is dropped but the engine
+    // client is KEPT — do NOT DisconnectEngine(). _engineComms is
+    // one-client-per-server and InitComms() runs once per boot, so tearing down
+    // here on a transient EAGAIN would sever anim->engine for the rest of the boot
+    // (permanent NO_ROBOT_COMMS). Pre-#26 this hit `bytesSent < length` because
+    // Send returned -1 on EAGAIN; post-#26 it returns the 0 sentinel, which still
+    // routed here until this branch.
+    LOG_WARNING("AnimComms.SendPacketToEngine.WouldBlock",
+                "Dropped %d-byte packet to engine: send would block; client kept", length);
+    return false;
+  }
   if (bytesSent < (ssize_t) length) {
+    // Hard error (-1; a >0 partial send cannot happen on DGRAM). LocalUdpServer
+    // does not tear down its client registration internally, so that is still
+    // this caller's job on a genuinely broken channel.
     LOG_ERROR("AnimComms.SendPacketToEngine.FailedSend",
               "Failed to send msg contents (%zd of %d bytes sent)",
               bytesSent, length);
@@ -238,7 +254,19 @@ bool SendPacketToRobot(const void *buffer, const u32 length)
   }
 
   const ssize_t bytesSent = _robotComms.Send((const char*)buffer, length);
+  if (bytesSent == 0) {
+    // Would-block (LocalUdpClient::Send tri-state contract): the datagram was
+    // dropped but the socket is KEPT — do NOT DisconnectRobot() on a transient
+    // condition. (A 0 with IsConnected() false would mean "socket undefined", but
+    // that is unreachable here because of the IsConnected() guard above.)
+    LOG_WARNING("SendPacketToRobot.WouldBlock",
+                "Dropped %d-byte packet to robot: send would block; connection kept", length);
+    return false;
+  }
   if (bytesSent < (ssize_t) length) {
+    // Hard error (-1): LocalUdpClient::Send has already Disconnect()ed the socket
+    // internally; the DisconnectRobot() below is a harmless idempotent no-op kept
+    // for defensiveness.
     LOG_ERROR("SendPacketToRobot.FailedSend", "Failed to send msg contents (%zd bytes sent)", bytesSent);
     DisconnectRobot();
     return false;

--- a/coretech/messaging/shared/LocalUdpClient.cpp
+++ b/coretech/messaging/shared/LocalUdpClient.cpp
@@ -24,10 +24,14 @@
 // Define this to enable logs
 #define LOG_CHANNEL                    "LocalUdpClient"
 
-#ifdef VICOS
-// todo: restore logging when vicos toolchain is available -PRA (approved by BRC)
-#undef LOG_CHANNEL
-#endif
+// NOTE: this file historically undefined LOG_CHANNEL on VICOS ("todo: restore
+// logging when vicos toolchain is available -PRA"). The sibling primitive
+// LocalUdpServer.cpp compiles the identical CORETECH_LOG_* macros for VICOS
+// today (its LocalUdpServer.Send.WouldBlock line is what the deployed engine
+// binary logs on the robot), so the toolchain limitation is long gone. Logging
+// is restored here because the Send.WouldBlock warning below is the on-robot
+// evidence that a datagram was dropped for backpressure (vs a dead socket) —
+// it must be visible to verify the client-side legs on deploy day.
 
 #ifdef  LOG_CHANNEL
 #define LOG_ERROR(name, format, ...)   CORETECH_LOG_ERROR(name, format, ##__VA_ARGS__)
@@ -161,6 +165,10 @@ bool LocalUdpClient::Disconnect()
 ssize_t LocalUdpClient::Send(const char* data, size_t size)
 {
   if (_socket < 0) {
+    // Pre-existing sentinel collision: this path ALSO returns 0 (see the header
+    // contract). Distinguishable from a would-block 0 at the call site because
+    // IsConnected() is false here, and by this ERROR log vs the WouldBlock
+    // WARNING below.
     LOG_ERROR("LocalUdpClient.Send", "Socket undefined, skipping send");
     return 0;
   }
@@ -169,9 +177,21 @@ ssize_t LocalUdpClient::Send(const char* data, size_t size)
 
   const ssize_t bytes_sent = send(_socket, data, size, 0);
 
+  if (bytes_sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    // Transient backpressure: the peer's kernel buffer is momentarily full and this
+    // is a non-blocking socket. The datagram is dropped, but the socket is still
+    // healthy — report 0 so callers keep the connection and retry later, instead of
+    // tearing down the channel on a recoverable condition. Mirrors the
+    // LocalUdpServer::Send would-block contract (fork #26 / orchestrator #4689).
+    LOG_WARNING("LocalUdpClient.Send.WouldBlock",
+                "Dropped %zu-byte datagram on %s (sock: %d): send would block; socket kept",
+                size, _sockname.c_str(), _socket);
+    return 0;
+  }
+
   if (bytes_sent != size) {
-    LOG_ERROR("LocalUdpClient.Send.Fail", 
-              "Send error on %s (sock: %d), disconnecting (%s)", 
+    LOG_ERROR("LocalUdpClient.Send.Fail",
+              "Send error on %s (sock: %d), disconnecting (%s)",
               _sockname.c_str(), _socket, strerror(errno));
     Disconnect();
     return -1;
@@ -191,17 +211,23 @@ ssize_t LocalUdpClient::Recv(char* data, size_t maxSize)
 
   const ssize_t bytes_received = recv(_socket, data, maxSize, 0);
 
-  if (bytes_received <= 0) {
-    if (errno == EWOULDBLOCK) {
+  if (bytes_received == 0) {
+    // Zero-length datagram (legal on DGRAM). errno is NOT meaningful here — the
+    // old `<= 0` + errno test read a stale errno on this path and could spuriously
+    // Disconnect the channel. Treat as "no data".
+    return 0;
+  }
+
+  if (bytes_received < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
       //LOG_DEBUG("LocalUdpClient.Recv", "No data available");
       return 0;
-    } else {
-      LOG_ERROR("LocalUdpClient.Recv.Fail", 
-                "Receive error on %s (sock: %d), dropping connection (%s)", 
-                _sockname.c_str(), _socket, strerror(errno));
-      Disconnect();
-      return -1;
     }
+    LOG_ERROR("LocalUdpClient.Recv.Fail",
+              "Receive error on %s (sock: %d), dropping connection (%s)",
+              _sockname.c_str(), _socket, strerror(errno));
+    Disconnect();
+    return -1;
   }
 
   //LOG_DEBUG("LocalUdpClient.Recv", "Received %zd bytes", bytes_received);

--- a/coretech/messaging/shared/LocalUdpClient.h
+++ b/coretech/messaging/shared/LocalUdpClient.h
@@ -28,6 +28,27 @@ public:
   bool IsConnected() const { return _socket >= 0; }
   bool Disconnect();
 
+  // Peer transport
+  //
+  // Send returns the number of bytes sent, or:
+  //   0  - EITHER the send would block (EAGAIN/EWOULDBLOCK on this non-blocking
+  //        socket): the datagram was dropped but the socket is KEPT; the caller
+  //        may retry later and MUST NOT treat this as a broken channel —
+  //        OR the socket is undefined (never connected / already disconnected),
+  //        a pre-existing sentinel this class has always returned.
+  //        The two are distinguishable at the call site: after a would-block 0,
+  //        IsConnected() is true and a "LocalUdpClient.Send.WouldBlock" WARNING
+  //        was logged; after an undefined-socket 0, IsConnected() is false and a
+  //        "LocalUdpClient.Send" ERROR was logged. Log-readers must not attribute
+  //        a dead-socket 0 to backpressure.
+  //   -1 - hard socket error; the socket has ALREADY been Disconnect()ed
+  //        internally. The channel is broken.
+  //
+  // Recv returns the number of bytes received, or:
+  //   0  - nothing to read (would-block / zero-length datagram / undefined
+  //        socket). Socket KEPT (when defined).
+  //   -1 - hard socket error; the socket has ALREADY been Disconnect()ed
+  //        internally.
   ssize_t Send(const char* data, size_t size);
   ssize_t Recv(char* data, size_t maxSize);
 

--- a/coretech/messaging/shared/LocalUdpServer.cpp
+++ b/coretech/messaging/shared/LocalUdpServer.cpp
@@ -181,6 +181,17 @@ ssize_t LocalUdpServer::Send(const char* data, size_t size)
     bytes_sent = sendto(_socket, data, size, 0, (sockaddr*)&_client, socklen);
   }
 
+  if (bytes_sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    // Transient backpressure: the peer's kernel buffer is momentarily full and this
+    // is a non-blocking socket. The datagram is dropped, but the client connection
+    // is still healthy — report 0 so callers keep the client and retry later,
+    // instead of tearing down the sole client on a recoverable condition.
+    LOG_WARNING("LocalUdpServer.Send.WouldBlock",
+                "Dropped %zu-byte datagram on %s (sock: %d): send would block; client kept",
+                size, _sockname.c_str(), _socket);
+    return 0;
+  }
+
   if (bytes_sent != size) {
     // If send fails, log it and report it to caller.  It is caller's responsibility to retry at
     // some appropriate interval.
@@ -200,16 +211,23 @@ ssize_t LocalUdpServer::Recv(char* data, size_t maxSize)
 
   const ssize_t bytes_received = recvfrom(_socket, data, maxSize, 0, (struct sockaddr *)&saddr, &saddrlen);
 
-  if (bytes_received <= 0) {
-    if (errno == EWOULDBLOCK) {
+  if (bytes_received == 0) {
+    // Zero-length datagram (legal on DGRAM). errno is NOT meaningful here — the
+    // old `<= 0` + errno test read a stale errno on this path and could surface a
+    // spurious -1 (which callers such as the robot HAL radio turn into a
+    // DisconnectRadio). Treat as "no data".
+    return 0;
+  }
+
+  if (bytes_received < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
       //LOG_DEBUG("LocalUdpServer.Recv", "No data available");
       return 0;
-    } else {
-      LOG_ERROR("LocalUdpServer.Recv.Fail",
-                "Receive error on %s (sock: %d) (%s)",
-                _sockname.c_str(), _socket, strerror(errno));
-      return -1;
     }
+    LOG_ERROR("LocalUdpServer.Recv.Fail",
+              "Receive error on %s (sock: %d) (%s)",
+              _sockname.c_str(), _socket, strerror(errno));
+    return -1;
   }
 
   //LOG_DEBUG("LocalUdpServer.Recv", "Received %zd bytes from %s", bytes_received, to_string(saddr, saddrlen).c_str());

--- a/coretech/messaging/shared/LocalUdpServer.h
+++ b/coretech/messaging/shared/LocalUdpServer.h
@@ -40,6 +40,20 @@ public:
   void SetBindClients(bool value) { _bindClients = value; }
 
   // Client transport
+  //
+  // Send returns the number of bytes sent, or:
+  //   0  - the send would block (EAGAIN/EWOULDBLOCK on this non-blocking socket).
+  //        The datagram was dropped but the client is still connected; the caller
+  //        may retry later and MUST NOT treat this as a broken channel.
+  //   -1 - hard socket error or no client. The channel is broken; callers that
+  //        own the client lifecycle should Disconnect().
+  // (0 is also returned for a zero-size send, which sends nothing.)
+  //
+  // Recv returns the number of bytes received, or:
+  //   0  - nothing to read (would-block / zero-length datagram / connection
+  //        packet). NOT an error; the client is kept.
+  //   -1 - hard socket error. Callers that own the client lifecycle decide
+  //        whether to Disconnect().
   ssize_t Send(const char* data, size_t size);
   ssize_t Recv(char* data, size_t maxSize);
 

--- a/coretech/messaging/test/host/CMakeLists.txt
+++ b/coretech/messaging/test/host/CMakeLists.txt
@@ -1,0 +1,73 @@
+#
+# coretech/messaging/test/host/CMakeLists.txt
+#
+# Native (Linux x86_64) host build of the cti_messaging unit tests.
+#
+# Standalone CMake project, NOT part of the main victor cross-compile graph —
+# same pattern as coretech/planning/test/host/ (see that CMakeLists for the
+# full rationale). LocalUdpServer/LocalUdpClient are plain POSIX local-domain
+# socket code, so they exercise the identical kernel behavior (unix DGRAM
+# flow control, EAGAIN on a full peer queue) on the host as on VICOS.
+#
+# USAGE
+# -----
+#   scripts/run-host-tests.sh                  # builds + runs all host suites
+# or manually:
+#   cmake -S coretech/messaging/test/host -B _build/host-messaging -DREPO_ROOT=$(pwd)
+#   cmake --build _build/host-messaging -j
+#   ctest --test-dir _build/host-messaging --output-on-failure
+#
+cmake_minimum_required(VERSION 3.16)
+project(cti_messaging_host_tests CXX)
+
+if(NOT DEFINED REPO_ROOT)
+  get_filename_component(REPO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+endif()
+message(STATUS "cti_messaging host tests: REPO_ROOT = ${REPO_ROOT}")
+
+if(NOT EXISTS "${REPO_ROOT}/coretech/messaging/shared/LocalUdpServer.cpp")
+  message(FATAL_ERROR
+    "REPO_ROOT (${REPO_ROOT}) does not look like a wire-os-victor checkout. "
+    "Pass -DREPO_ROOT=/path/to/wire-os-victor.")
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CT    "${REPO_ROOT}/coretech")
+set(UTIL  "${REPO_ROOT}/lib/util/source")
+set(GTEST "${REPO_ROOT}/lib/das-client/testing/gtest/fused-src")
+
+include_directories(
+  ${REPO_ROOT}
+  ${UTIL}/anki
+  ${GTEST}
+)
+
+# logging.h requires exactly one of CORETECH_ROBOT/ENGINE/SHARED to pick a log
+# level; the messaging sources live in the shared tier.
+add_compile_definitions(CORETECH_SHARED)
+
+add_executable(cti_messaging_test
+  ${CT}/messaging/shared/LocalUdpServer.cpp
+  ${CT}/messaging/shared/LocalUdpClient.cpp
+  ${CT}/messaging/shared/SocketUtils.cpp
+  ${CT}/messaging/test/testLocalUdpServer.cpp
+  ${CT}/messaging/test/testLocalUdpClient.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/logging_stubs.cpp
+  ${GTEST}/gtest/gtest-all.cc
+  ${GTEST}/gtest/gtest_main.cc
+)
+
+find_package(Threads REQUIRED)
+target_link_libraries(cti_messaging_test PRIVATE Threads::Threads)
+
+enable_testing()
+add_test(NAME cti_messaging_test COMMAND cti_messaging_test)
+set_tests_properties(cti_messaging_test PROPERTIES
+  ENVIRONMENT "GTEST_OUTPUT=xml:${CMAKE_BINARY_DIR}/ctiMessagingGoogleTest.xml"
+  TIMEOUT 120
+)

--- a/coretech/messaging/test/host/logging_stubs.cpp
+++ b/coretech/messaging/test/host/logging_stubs.cpp
@@ -1,0 +1,67 @@
+/**
+ * File: logging_stubs.cpp
+ *
+ * Description: Host-test stand-ins for the Anki::CoreTech logging entry
+ * points. The real coretech/common/shared/logging.cpp forwards into the full
+ * Anki::Util logging stack (logger providers, string tables, console system),
+ * none of which is under test here. These stubs print to stderr so failing
+ * socket tests still show the firmware's own diagnostics.
+ *
+ * Same pattern as coretech/planning/test/host/cv_stubs.cpp.
+ */
+
+#include "coretech/common/shared/logging.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace {
+
+void Print(const char* level, const char* name, const char* format, va_list args)
+{
+  fprintf(stderr, "[%s] %s: ", level, name);
+  vfprintf(stderr, format, args);
+  fprintf(stderr, "\n");
+}
+
+} // anonymous namespace
+
+namespace Anki {
+namespace CoreTech {
+
+void LogError(const char* name, const char* format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  Print("ERROR", name, format, args);
+  va_end(args);
+}
+
+void LogWarning(const char* name, const char* format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  Print("WARN", name, format, args);
+  va_end(args);
+}
+
+void LogInfo(const char* channel, const char* name, const char* format, ...)
+{
+  (void)channel;
+  va_list args;
+  va_start(args, format);
+  Print("INFO", name, format, args);
+  va_end(args);
+}
+
+void LogDebug(const char* channel, const char* name, const char* format, ...)
+{
+  (void)channel;
+  va_list args;
+  va_start(args, format);
+  Print("DEBUG", name, format, args);
+  va_end(args);
+}
+
+} // namespace CoreTech
+} // namespace Anki

--- a/coretech/messaging/test/testLocalUdpClient.cpp
+++ b/coretech/messaging/test/testLocalUdpClient.cpp
@@ -1,0 +1,389 @@
+/**
+ * File: testLocalUdpClient.cpp
+ *
+ * Description: gtest cases for LocalUdpClient transport semantics over real
+ * local-domain DGRAM sockets, plus contract-mirror tests for the (non
+ * host-buildable) callers whose disconnect-on-EAGAIN behavior this change
+ * fixes. The focus is the Send()/Recv() return contract — the client-side
+ * mirror of the LocalUdpServer contract fixed for orchestrator #4689 (fork
+ * #26):
+ *
+ *     >0  datagram sent / received
+ *      0  the send would block (EAGAIN/EWOULDBLOCK) or there is nothing to
+ *         read — datagram dropped, socket KEPT. Also the pre-existing sentinel
+ *         for an undefined socket (distinguishable: IsConnected() is false).
+ *     -1  hard socket error — the client has ALREADY Disconnect()ed itself.
+ *
+ * Pre-fix, LocalUdpClient::Send() called Disconnect() on ANY incomplete send,
+ * including a transient EAGAIN when the peer's kernel receive queue was
+ * momentarily full. Every caller of the client (engine->anim
+ * RobotConnectionManager, anim->robot AnimComms::SendPacketToRobot, jdocs, log
+ * uploader, switchboard engine/token clients) therefore lost its channel to one
+ * burst of backpressure — the reverse direction of the engine->gateway jam
+ * (orchestrator #4672). These tests assert the socket survives the EAGAIN and
+ * carries traffic again once the peer drains (orchestrator #4715).
+ *
+ * Copyright: Anki, inc. 2026
+ */
+
+#include "coretech/messaging/shared/LocalUdpClient.h"
+#include "coretech/messaging/shared/LocalUdpServer.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+namespace {
+
+std::string SocketPath(const char* tag)
+{
+  return "/tmp/testLocalUdpClient_" + std::string(tag) + "_" + std::to_string(getpid());
+}
+
+// Small kernel buffers so a short unread burst reaches backpressure. The
+// kernel rounds these up to its floor (and doubles them), so the tests flood
+// generously rather than assuming an exact capacity.
+constexpr int kSmallBufSz = 4096;
+constexpr size_t kDatagramSize = 1024;
+constexpr int kMaxFloodDatagrams = 4096;
+
+// A client connected to a server that does NOT drain unless told to — the
+// client->server mirror of the ServerClientPair in testLocalUdpServer.cpp.
+struct ClientServerPair {
+  LocalUdpServer server{kSmallBufSz, kSmallBufSz};
+  LocalUdpClient client{kSmallBufSz, kSmallBufSz};
+  std::string serverPath;
+  std::string clientPath;
+
+  explicit ClientServerPair(const char* tag)
+  : serverPath(SocketPath((std::string(tag) + "_server").c_str()))
+  , clientPath(SocketPath((std::string(tag) + "_client").c_str()))
+  {
+  }
+
+  ~ClientServerPair()
+  {
+    client.Disconnect();
+    server.StopListening();
+    unlink(serverPath.c_str());
+    unlink(clientPath.c_str());
+  }
+
+  // Start the server, connect the client, and consume the connection packet the
+  // client sends on Connect() (server registers the client and returns 0 for
+  // it). After this, the server's recv queue holds only real payload datagrams,
+  // so DrainServer() can loop on the Recv() return value alone.
+  ::testing::AssertionResult Establish()
+  {
+    if (!server.StartListening(serverPath)) {
+      return ::testing::AssertionFailure() << "server failed to listen on " << serverPath;
+    }
+    if (!client.Connect(clientPath, serverPath)) {
+      return ::testing::AssertionFailure() << "client failed to connect to " << serverPath;
+    }
+    char buf[64];
+    if (server.Recv(buf, sizeof(buf)) < 0) {
+      return ::testing::AssertionFailure() << "server Recv failed on connection packet";
+    }
+    if (!server.HasClient()) {
+      return ::testing::AssertionFailure() << "server did not register the client";
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  // Client sends datagrams without the server draining until Send() reports
+  // something other than a full send. Returns that first non-full-size result,
+  // or the last full-size result if backpressure was never reached.
+  ssize_t FloodUntilNotSent()
+  {
+    const std::vector<char> datagram(kDatagramSize, 'x');
+    ssize_t res = -1;
+    for (int i = 0; i < kMaxFloodDatagrams; ++i) {
+      res = client.Send(datagram.data(), datagram.size());
+      if (res != (ssize_t)datagram.size()) {
+        return res;
+      }
+    }
+    return res;
+  }
+
+  // Drain everything queued on the server side. The connection packet was
+  // already consumed in Establish(), so the queue holds only full-size payload
+  // datagrams and Recv() returns >0 until the queue empties (then 0).
+  void DrainServer()
+  {
+    std::vector<char> rbuf(kDatagramSize * 2);
+    while (server.Recv(rbuf.data(), rbuf.size()) > 0) {
+    }
+  }
+};
+
+} // anonymous namespace
+
+// Pre-existing sentinel: an undefined socket returns 0 from Send. The
+// disambiguation from a would-block 0 is IsConnected() — pin it with a test so
+// the collision named in the header contract stays true.
+TEST(LocalUdpClient, SendWithUndefinedSocketReturnsZeroAndNotConnected)
+{
+  LocalUdpClient client;
+  ASSERT_FALSE(client.IsConnected());
+
+  const char data[] = "hello";
+  EXPECT_EQ(client.Send(data, sizeof(data)), 0);
+  EXPECT_FALSE(client.IsConnected());
+}
+
+TEST(LocalUdpClient, RoundTripDelivery)
+{
+  ClientServerPair pair("roundtrip");
+  ASSERT_TRUE(pair.Establish());
+
+  const char data[] = "ping";
+  ASSERT_EQ(pair.client.Send(data, sizeof(data)), (ssize_t)sizeof(data));
+
+  char buf[64];
+  EXPECT_EQ(pair.server.Recv(buf, sizeof(buf)), (ssize_t)sizeof(data));
+  EXPECT_STREQ(buf, "ping");
+}
+
+// The client-side jam scenario: backpressure must surface as 0 (drop, keep
+// socket), never as the -1-with-internal-Disconnect that killed the channel.
+TEST(LocalUdpClient, WouldBlockReturnsZeroAndKeepsSocket)
+{
+  ClientServerPair pair("wouldblock");
+  ASSERT_TRUE(pair.Establish());
+
+  const ssize_t res = pair.FloodUntilNotSent();
+  ASSERT_EQ(res, 0) << "expected would-block sentinel 0 (got " << res
+                    << "); -1 means EAGAIN is still a hard error that Disconnect()ed the socket";
+  EXPECT_TRUE(pair.client.IsConnected());
+}
+
+// After the peer drains its queue, the SAME socket must carry traffic again.
+// Pre-fix, the EAGAIN-triggered internal Disconnect() left the client dead
+// until its owner ran a full reconnect (which several owners never do).
+TEST(LocalUdpClient, ChannelRecoversAfterWouldBlock)
+{
+  ClientServerPair pair("recovery");
+  ASSERT_TRUE(pair.Establish());
+
+  ASSERT_EQ(pair.FloodUntilNotSent(), 0);
+  ASSERT_TRUE(pair.client.IsConnected());
+
+  pair.DrainServer();
+
+  const std::vector<char> datagram(kDatagramSize, 'y');
+  EXPECT_EQ(pair.client.Send(datagram.data(), datagram.size()), (ssize_t)datagram.size());
+
+  std::vector<char> rbuf(kDatagramSize * 2);
+  EXPECT_EQ(pair.server.Recv(rbuf.data(), rbuf.size()), (ssize_t)datagram.size());
+}
+
+// A genuinely broken channel must still be reported as -1, and the client still
+// tears itself down (hard-error behavior unchanged).
+TEST(LocalUdpClient, HardErrorReturnsMinusOneAndDisconnects)
+{
+  ClientServerPair pair("harderror");
+  ASSERT_TRUE(pair.Establish());
+
+  // Closing the server socket makes subsequent connected sends fail with
+  // ECONNREFUSED — a hard error, not backpressure.
+  pair.server.StopListening();
+
+  const char data[] = "into the void";
+  EXPECT_EQ(pair.client.Send(data, sizeof(data)), -1);
+  EXPECT_FALSE(pair.client.IsConnected());
+}
+
+// Recv with nothing pending is transient: 0, socket kept.
+TEST(LocalUdpClient, RecvWouldBlockReturnsZeroAndKeepsSocket)
+{
+  ClientServerPair pair("recvwouldblock");
+  ASSERT_TRUE(pair.Establish());
+
+  char buf[64];
+  EXPECT_EQ(pair.client.Recv(buf, sizeof(buf)), 0);
+  EXPECT_TRUE(pair.client.IsConnected());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Caller-contract mirrors.
+//
+// RobotConnectionManager / AnimComms / HAL radio are not host-buildable (they
+// drag the engine/anim/robot CLAD build graphs). Their exact decision trees are
+// replicated verbatim here against the real primitives so the branch this fix
+// adds is regression-tested; the 5-line class branches themselves are validated
+// live in the supervised deploy window.
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+namespace {
+
+// Verbatim mirror of RobotConnectionManager::SendData()'s NEW decision tree
+// (engine/comms/robotConnectionManager.cpp), a LocalUdpClient caller
+// (engine->anim). Would-block 0 -> return false, connection KEPT; hard error ->
+// disconnect.
+bool SendDataPerRobotConnectionManagerContract(LocalUdpClient& udpClient,
+                                               const uint8_t* buffer,
+                                               unsigned int size,
+                                               bool& disconnectedOut)
+{
+  disconnectedOut = false;
+
+  const ssize_t sent = udpClient.Send((const char *) buffer, size);
+  if (sent == 0) {
+    // Would-block: drop and keep (the fix). Pre-fix this fell into the
+    // `sent != size` teardown below and tore down the engine->anim connection.
+    return false;
+  }
+  if (sent != size) {
+    // DisconnectCurrent() equivalent.
+    if (udpClient.IsConnected()) {
+      udpClient.Disconnect();
+    }
+    disconnectedOut = true;
+    return false;
+  }
+  return true;
+}
+
+// Verbatim mirror of the LocalUdpServer-caller decision tree shared by
+// HAL::RadioSendPacket (robot/hal/src/radio.cpp, robot->anim) and
+// AnimComms::SendPacketToEngine (animProcess/.../animComms.cpp, anim->engine).
+// Would-block 0 -> return false, client KEPT (NO Disconnect); hard error ->
+// caller Disconnect()s (the server does not self-tear-down).
+bool SendPacketPerServerCallerContract(LocalUdpServer& server,
+                                       const char* buffer,
+                                       size_t length,
+                                       bool& disconnectedOut)
+{
+  disconnectedOut = false;
+  if (!server.HasClient()) {
+    return false;
+  }
+  const ssize_t bytesSent = server.Send(buffer, length);
+  if (bytesSent == 0) {
+    // Would-block: drop and keep (the fix). Pre-fix this fell into the
+    // `bytesSent < length` teardown below and DisconnectRadio()/DisconnectEngine().
+    return false;
+  }
+  if (bytesSent < (ssize_t) length) {
+    server.Disconnect();
+    disconnectedOut = true;
+    return false;
+  }
+  return true;
+}
+
+} // anonymous namespace
+
+// Orchestrator #4715 item 2a: one transient EAGAIN on the engine->anim socket
+// must NOT make the engine treat the robot as gone. Would-block send ->
+// connection retained -> subsequent send succeeds.
+TEST(RobotConnectionManagerContract, WouldBlockSendKeepsConnection)
+{
+  ClientServerPair pair("rcmcontract");
+  ASSERT_TRUE(pair.Establish());
+
+  const std::vector<uint8_t> message(kDatagramSize, 'm');
+  bool disconnected = false;
+  bool sendResult = true;
+  for (int i = 0; i < kMaxFloodDatagrams && sendResult; ++i) {
+    sendResult = SendDataPerRobotConnectionManagerContract(
+        pair.client, message.data(), (unsigned int)message.size(), disconnected);
+  }
+  ASSERT_FALSE(sendResult) << "flood never reached backpressure";
+
+  EXPECT_FALSE(disconnected)
+      << "would-block send tore down the engine->anim connection "
+         "(RobotConnectionManager::Update() would return RESULT_FAIL_IO_CONNECTION_CLOSED)";
+  ASSERT_TRUE(pair.client.IsConnected());
+
+  pair.DrainServer();
+  EXPECT_TRUE(SendDataPerRobotConnectionManagerContract(
+      pair.client, message.data(), (unsigned int)message.size(), disconnected));
+  EXPECT_FALSE(disconnected);
+}
+
+// Hard errors must still tear down through the same contract.
+TEST(RobotConnectionManagerContract, HardErrorStillDisconnects)
+{
+  ClientServerPair pair("rcmharderror");
+  ASSERT_TRUE(pair.Establish());
+
+  pair.server.StopListening();
+
+  const std::vector<uint8_t> message(kDatagramSize, 'm');
+  bool disconnected = false;
+  EXPECT_FALSE(SendDataPerRobotConnectionManagerContract(
+      pair.client, message.data(), (unsigned int)message.size(), disconnected));
+  EXPECT_TRUE(disconnected);
+  EXPECT_FALSE(pair.client.IsConnected());
+}
+
+// Orchestrator #4715 items 2b/2c: one transient EAGAIN on the robot->anim
+// (HAL::RadioSendPacket) or anim->engine (AnimComms::SendPacketToEngine) socket
+// must NOT DisconnectRadio()/DisconnectEngine() — which, because InitComms()/
+// InitRadio() run once per boot, would sever the channel until reboot.
+TEST(ServerCallerContract, WouldBlockSendKeepsClient)
+{
+  // Server floods its sole client without the client draining; Send() surfaces
+  // backpressure as 0 and the caller must keep the client.
+  const std::string serverPath = SocketPath("servercaller_server");
+  const std::string clientPath = SocketPath("servercaller_client");
+  LocalUdpServer server{kSmallBufSz, kSmallBufSz};
+  LocalUdpClient client{kSmallBufSz, kSmallBufSz};
+  ASSERT_TRUE(server.StartListening(serverPath));
+  ASSERT_TRUE(client.Connect(clientPath, serverPath));
+  char cbuf[64];
+  ASSERT_GE(server.Recv(cbuf, sizeof(cbuf)), 0);
+  ASSERT_TRUE(server.HasClient());
+
+  const std::vector<char> datagram(kDatagramSize, 'x');
+  bool disconnected = false;
+  bool sendResult = true;
+  for (int i = 0; i < kMaxFloodDatagrams && sendResult; ++i) {
+    sendResult = SendPacketPerServerCallerContract(
+        server, datagram.data(), datagram.size(), disconnected);
+  }
+  ASSERT_FALSE(sendResult) << "flood never reached backpressure";
+  EXPECT_FALSE(disconnected)
+      << "would-block send tore down the sole client (DisconnectRadio/DisconnectEngine)";
+  EXPECT_TRUE(server.HasClient());
+
+  client.Disconnect();
+  server.StopListening();
+  unlink(serverPath.c_str());
+  unlink(clientPath.c_str());
+}
+
+// Hard errors must still tear the client down through the same caller contract.
+TEST(ServerCallerContract, HardErrorDisconnectsClient)
+{
+  const std::string serverPath = SocketPath("servercaller_hard_server");
+  const std::string clientPath = SocketPath("servercaller_hard_client");
+  LocalUdpServer server{kSmallBufSz, kSmallBufSz};
+  LocalUdpClient client{kSmallBufSz, kSmallBufSz};
+  ASSERT_TRUE(server.StartListening(serverPath));
+  ASSERT_TRUE(client.Connect(clientPath, serverPath));
+  char cbuf[64];
+  ASSERT_GE(server.Recv(cbuf, sizeof(cbuf)), 0);
+  ASSERT_TRUE(server.HasClient());
+
+  // Client gone -> connected send fails with ECONNREFUSED (hard error).
+  client.Disconnect();
+
+  const std::vector<char> datagram(kDatagramSize, 'x');
+  bool disconnected = false;
+  EXPECT_FALSE(SendPacketPerServerCallerContract(
+      server, datagram.data(), datagram.size(), disconnected));
+  EXPECT_TRUE(disconnected);
+  EXPECT_FALSE(server.HasClient());
+
+  server.StopListening();
+  unlink(serverPath.c_str());
+  unlink(clientPath.c_str());
+}

--- a/coretech/messaging/test/testLocalUdpServer.cpp
+++ b/coretech/messaging/test/testLocalUdpServer.cpp
@@ -1,0 +1,178 @@
+/**
+ * File: testLocalUdpServer.cpp
+ *
+ * Description: gtest cases for LocalUdpServer client-transport semantics over
+ * real local-domain DGRAM sockets. The focus is the Send() return contract:
+ *
+ *     >0  datagram sent
+ *      0  send would block (EAGAIN/EWOULDBLOCK) — datagram dropped, client KEPT
+ *     -1  hard socket error or no client — channel broken
+ *
+ * The would-block case reproduces the engine→gateway response jam: a burst of
+ * unread datagrams fills the peer's kernel receive queue, the server's
+ * non-blocking send() returns EAGAIN ("Resource temporarily unavailable"),
+ * and — because LocalUdpServer is one-client-per-server — disconnecting on
+ * that transient condition used to kill every subsequent response until the
+ * next boot. These tests assert the channel survives the EAGAIN and carries
+ * traffic again once the peer drains.
+ *
+ * Copyright: Anki, inc. 2026
+ */
+
+#include "coretech/messaging/shared/LocalUdpServer.h"
+#include "coretech/messaging/shared/LocalUdpClient.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+namespace {
+
+std::string SocketPath(const char* tag)
+{
+  return "/tmp/testLocalUdpServer_" + std::string(tag) + "_" + std::to_string(getpid());
+}
+
+// Small kernel buffers so a short unread burst reaches backpressure. The
+// kernel rounds these up to its floor (and doubles them), so the test floods
+// generously rather than assuming an exact capacity.
+constexpr int kSmallBufSz = 4096;
+constexpr size_t kDatagramSize = 1024;
+constexpr int kMaxFloodDatagrams = 4096;
+
+struct ServerClientPair {
+  LocalUdpServer server;
+  LocalUdpClient client{kSmallBufSz, kSmallBufSz};
+  std::string serverPath;
+  std::string clientPath;
+
+  explicit ServerClientPair(const char* tag)
+  : serverPath(SocketPath((std::string(tag) + "_server").c_str()))
+  , clientPath(SocketPath((std::string(tag) + "_client").c_str()))
+  {
+  }
+
+  ~ServerClientPair()
+  {
+    client.Disconnect();
+    server.StopListening();
+    unlink(serverPath.c_str());
+    unlink(clientPath.c_str());
+  }
+
+  // Start the server, connect the client, and let the server register the
+  // client from the connection packet the client sends on Connect().
+  ::testing::AssertionResult Establish()
+  {
+    if (!server.StartListening(serverPath)) {
+      return ::testing::AssertionFailure() << "server failed to listen on " << serverPath;
+    }
+    if (!client.Connect(clientPath, serverPath)) {
+      return ::testing::AssertionFailure() << "client failed to connect to " << serverPath;
+    }
+    char buf[64];
+    if (server.Recv(buf, sizeof(buf)) < 0) {
+      return ::testing::AssertionFailure() << "server Recv failed on connection packet";
+    }
+    if (!server.HasClient()) {
+      return ::testing::AssertionFailure() << "server did not register the client";
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  // Send datagrams without the client draining until Send() reports
+  // backpressure. Returns the first non-full-size Send() result, or the last
+  // full-size result if backpressure was never reached.
+  ssize_t FloodUntilNotSent()
+  {
+    const std::vector<char> datagram(kDatagramSize, 'x');
+    ssize_t res = -1;
+    for (int i = 0; i < kMaxFloodDatagrams; ++i) {
+      res = server.Send(datagram.data(), datagram.size());
+      if (res != (ssize_t)datagram.size()) {
+        return res;
+      }
+    }
+    return res;
+  }
+};
+
+} // anonymous namespace
+
+TEST(LocalUdpServer, SendWithNoClientReturnsMinusOne)
+{
+  const std::string serverPath = SocketPath("noclient");
+  LocalUdpServer server;
+  ASSERT_TRUE(server.StartListening(serverPath));
+
+  const char data[] = "hello";
+  EXPECT_EQ(server.Send(data, sizeof(data)), -1);
+
+  server.StopListening();
+  unlink(serverPath.c_str());
+}
+
+TEST(LocalUdpServer, RoundTripDelivery)
+{
+  ServerClientPair pair("roundtrip");
+  ASSERT_TRUE(pair.Establish());
+
+  const char data[] = "ping";
+  ASSERT_EQ(pair.server.Send(data, sizeof(data)), (ssize_t)sizeof(data));
+
+  char buf[64];
+  EXPECT_EQ(pair.client.Recv(buf, sizeof(buf)), (ssize_t)sizeof(data));
+  EXPECT_STREQ(buf, "ping");
+}
+
+// The engine→gateway jam scenario: backpressure must surface as 0 (drop, keep
+// client), never as the -1 that callers treat as a broken channel.
+TEST(LocalUdpServer, WouldBlockReturnsZeroAndKeepsClient)
+{
+  ServerClientPair pair("wouldblock");
+  ASSERT_TRUE(pair.Establish());
+
+  const ssize_t res = pair.FloodUntilNotSent();
+  ASSERT_EQ(res, 0) << "expected would-block sentinel 0 (got " << res
+                    << "); -1 means EAGAIN is still reported as a hard error";
+  EXPECT_TRUE(pair.server.HasClient());
+}
+
+// After the peer drains its queue, the SAME client connection must carry
+// traffic again. Pre-fix, the EAGAIN-triggered Disconnect() left the
+// one-client server clientless for the rest of the boot.
+TEST(LocalUdpServer, ChannelRecoversAfterWouldBlock)
+{
+  ServerClientPair pair("recovery");
+  ASSERT_TRUE(pair.Establish());
+
+  ASSERT_EQ(pair.FloodUntilNotSent(), 0);
+  ASSERT_TRUE(pair.server.HasClient());
+
+  // Drain everything queued on the client side.
+  std::vector<char> rbuf(kDatagramSize * 2);
+  while (pair.client.Recv(rbuf.data(), rbuf.size()) > 0) {
+  }
+
+  const std::vector<char> datagram(kDatagramSize, 'y');
+  EXPECT_EQ(pair.server.Send(datagram.data(), datagram.size()), (ssize_t)datagram.size());
+  EXPECT_EQ(pair.client.Recv(rbuf.data(), rbuf.size()), (ssize_t)datagram.size());
+}
+
+// A genuinely broken channel must still be reported as -1 so callers keep
+// their disconnect-on-hard-error behavior.
+TEST(LocalUdpServer, HardErrorStillReturnsMinusOne)
+{
+  ServerClientPair pair("harderror");
+  ASSERT_TRUE(pair.Establish());
+
+  // Closing the client socket makes subsequent connected sends fail with
+  // ECONNREFUSED — a hard error, not backpressure.
+  pair.client.Disconnect();
+
+  const char data[] = "into the void";
+  EXPECT_EQ(pair.server.Send(data, sizeof(data)), -1);
+}

--- a/engine/comms/robotConnectionManager.cpp
+++ b/engine/comms/robotConnectionManager.cpp
@@ -149,6 +149,21 @@ bool RobotConnectionManager::SendData(const uint8_t* buffer, unsigned int size)
   }
 
   const ssize_t sent = _udpClient.Send((const char *) buffer, size);
+  if (sent == 0) {
+    // Would-block (LocalUdpClient::Send tri-state contract): the anim process's
+    // kernel receive queue is momentarily full. The datagram is dropped but the
+    // socket is KEPT — do NOT DisconnectCurrent(). Pre-contract this fell into the
+    // `sent != size` teardown below, so ONE transient EAGAIN on the engine->anim
+    // socket made Update() return RESULT_FAIL_IO_CONNECTION_CLOSED and the engine
+    // treated the physical robot as gone (reverse direction of the engine->gateway
+    // jam fixed on the LocalUdpServer side, fork #26 / orchestrator #4689).
+    // Note: Send also returns 0 for an undefined socket, but then IsConnected() is
+    // already false and Update() reports CONNECTION_CLOSED anyway, so no teardown
+    // is lost by returning early here.
+    LOG_WARNING("RobotConnectionManager.SendData.WouldBlock",
+                "Dropped %u-byte message to robot: send would block; connection kept", size);
+    return false;
+  }
   if (sent != size) {
     LOG_ERROR("RobotConnectionManager.SendData.Error", "Sent %zd/%d bytes to robot", sent, size);
     DisconnectCurrent();

--- a/engine/cozmoAPI/comms/localUdpSocketComms.cpp
+++ b/engine/cozmoAPI/comms/localUdpSocketComms.cpp
@@ -120,6 +120,14 @@ bool LocalUdpSocketComms::SendMessageInternal(const Comms::MsgPacket& msgPacket)
       _udpServer->Disconnect();
       return false;
     }
+    if (res == 0) {
+      // Send would block (peer's kernel buffer full under load). The datagram is
+      // dropped but the client is intact — do NOT Disconnect(). LocalUdpServer is
+      // one-client-per-server, so disconnecting here on a transient EAGAIN severed
+      // the sole gateway client and every subsequent response was dropped
+      // ("No client") until the next boot.
+      return false;
+    }
     return true;
   }
   return false;

--- a/platform/switchboard/switchboardd/gatewayMessagingServer.cpp
+++ b/platform/switchboard/switchboardd/gatewayMessagingServer.cpp
@@ -295,6 +295,12 @@ bool GatewayMessagingServer::SendMessage(const SwitchboardResponse& message) {
       _server.Disconnect();
       return false;
     }
+    if (res == 0) {
+      // Would-block (LocalUdpServer::Send tri-state contract): the datagram was
+      // dropped but the client is kept. Report the drop honestly — returning true
+      // here would claim a dropped message was delivered.
+      return false;
+    }
     return true;
   }
   return false;

--- a/robot/hal/src/radio.cpp
+++ b/robot/hal/src/radio.cpp
@@ -77,6 +77,18 @@ namespace Anki {
     {
       if (server.HasClient()) {
         const ssize_t bytesSent = server.Send((char*)buffer, length);
+        if (bytesSent == 0) {
+          // Would-block (LocalUdpServer::Send tri-state contract): the anim
+          // process's kernel receive queue is momentarily full. The datagram is
+          // dropped but the anim client is KEPT — do NOT DisconnectRadio() on a
+          // transient condition. Pre-#26 this hit `bytesSent < length` because
+          // Send returned -1 on EAGAIN; post-#26 it returns the 0 sentinel, which
+          // still routed to the teardown below until this branch. In-tree
+          // precedent: hal.cpp's spine read already maps EAGAIN -> 0.
+          AnkiWarn("HAL.RadioSendPacket.WouldBlock",
+                   "Dropped %zu-byte packet: send would block; client kept", length);
+          return false;
+        }
         if (bytesSent < (ssize_t) length) {
           AnkiError("HAL.RadioSendPacket.FailedToSend", "Failed to send msg contents (%zd/%zu sent)", bytesSent, length);
           DisconnectRadio(false);


### PR DESCRIPTION
## Problem

`LocalUdpServer` / `LocalUdpClient` are one-client-per-server non-blocking unix-DGRAM primitives that carry the inter-process traffic (engine↔gateway, engine↔anim, anim↔robot, switchboard↔gateway). On a non-blocking DGRAM socket, `send()` returns `EAGAIN`/`EWOULDBLOCK` when the **peer's kernel receive queue is momentarily full** — a transient, recoverable backpressure condition, not a broken channel.

The stock code treats *any* incomplete transfer as a dead channel and tears the connection down:

```cpp
// LocalUdpClient::Send
if (bytes_sent != size) { ...; Disconnect(); return -1; }
```
```cpp
// callers, e.g. HAL::RadioSendPacket / AnimComms::SendPacketToEngine
if (bytesSent < (ssize_t) length) { ...; DisconnectRadio(false); return false; }
```

Because these channels are **one client per server** and their comms are initialized **once per boot**, a single transient `EAGAIN` **permanently severs the channel until reboot**.

We hit this in production on Vector 2.0: under sustained CPU load the gateway's single-goroutine reader falls behind, the engine's response socket returns `EAGAIN` ("Resource temporarily unavailable"), the sole gateway client is `Disconnect()`ed, and **every** subsequent SDK gRPC call returns `DeadlineExceeded` until the robot is rebooted. The same latent heuristic exists in the engine↔anim, anim↔robot and robot HAL radio paths.

## Fix — one tri-state Send/Recv contract, no per-caller EAGAIN heuristics

**Primitives** (`coretech/messaging/shared/LocalUdp{Server,Client}.{cpp,h}`):
- `Send` returns **`0`** on `EAGAIN`/`EWOULDBLOCK`: the datagram is dropped but the client/socket is **kept**; `-1` stays reserved for a hard error / no client. Callers may retry and must not treat `0` as a broken channel. (`LocalUdpClient::Send` has always also returned `0` for an undefined socket; the two are disambiguated by `IsConnected()` and by the log line — documented in the header.)
- `Recv` splits the old `<= 0` test so a **zero-length datagram** returns `0` instead of reading a stale `errno` and spuriously reporting `-1`.
- `LocalUdpClient` logging is restored on VICOS (the sibling `LocalUdpServer` already compiles the same `CORETECH_LOG_*` macros there), so the `Send.WouldBlock` warning is visible on-device.

**Callers** treat the `0` sentinel as drop-and-keep:
- `engine/cozmoAPI/comms/localUdpSocketComms.cpp` (engine→gateway)
- `engine/comms/robotConnectionManager.cpp` `SendData` (engine→anim)
- `animProcess/src/cozmoAnim/animComms.cpp` `SendPacketToEngine` / `SendPacketToRobot`
- `robot/hal/src/radio.cpp` `RadioSendPacket` (robot→anim)
- `platform/switchboard/switchboardd/gatewayMessagingServer.cpp` `SendMessage` now reports a dropped datagram as **not delivered** instead of returning `true`.

Every other `LocalUdpClient::Send` caller (`jdocsManager`, `robotLogUploader`, switchboard engine/token clients) was audited: each already treats `<= 0` as a soft failure and is **improved for free** (the socket survives the backpressure) with no code change.

## Tests

New host gtest suite exercising the contract over **real local-domain DGRAM sockets** with genuine `EAGAIN` (small kernel buffers → true backpressure), plus verbatim caller-contract mirrors for the sites that aren't host-buildable (they pull in the engine/anim/robot CLAD graphs):

- `coretech/messaging/test/testLocalUdpServer.cpp` — server primitive (would-block keeps client, hard error `-1`, recovery after drain).
- `coretech/messaging/test/testLocalUdpClient.cpp` — client primitive tri-state + `RobotConnectionManager` / HAL-radio caller-contract mirrors.

Standalone CMake project (not part of the cross-compile graph), so it runs on a plain Linux x86_64 host with no robot:

```
cmake -S coretech/messaging/test/host -B _build/host-messaging -DREPO_ROOT=$(pwd)
cmake --build _build/host-messaging -j
ctest --test-dir _build/host-messaging --output-on-failure
```

**15/15 pass** on this branch (built against the current `main` tree). Reverting only the `LocalUdpClient::Send` would-block branch fails the 3 client would-block tests, confirming the tests catch the regression.

## Notes

- Zero file overlap with anything else on `main`; every touched file exists here.
- Contributed from the downstream **ophir-sw/wire-os-victor** fork (where this rides on an already-deployed split of the same fix). Happy to adjust log-tag naming or split the host-test infra out into its own PR if you'd prefer to land the source fix first.
