### PR TITLE
Reonboard ccis option

### DIFF
--- a/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
+++ b/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
@@ -222,6 +222,9 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
   ADD_SCREEN(FAC, None);
   ADD_SCREEN(CustomText, None);
   ADD_SCREEN(Main, Network);
+  ADD_SCREEN_WITH_TEXT(UserDataSubmenu, UserDataSubmenu, {"DATA OPTIONS"});
+  ADD_SCREEN_WITH_TEXT(Reonboarding, Reonboarding, {"REONBOARDING..."});
+  ADD_SCREEN_WITH_TEXT(Reonboard, Reonboard, {"REONBOARD?"});
   ADD_SCREEN_WITH_TEXT(ClearUserData, Main, {"CLEAR OUT SOUL?"});
   ADD_SCREEN_WITH_TEXT(ClearUserDataFail, Main, {"UNABLE TO CLEAR SOUL"});
   ADD_SCREEN_WITH_TEXT(Rebooting, Rebooting, {"Vector will remember that..."});
@@ -317,7 +320,12 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
 #if ENABLE_SELF_TEST
   ADD_MENU_ITEM(Main, IsXray() ? "TEST" : "SELF TEST", SelfTest);
 #endif
-  ADD_MENU_ITEM(Main, IsXray() ? "CLEAR" : "CLEAR OUT SOUL", ClearUserData);
+  ADD_MENU_ITEM(Main, IsXray() ? "DATA" : "DATA OPTIONS", UserDataSubmenu);
+
+  ADD_MENU_ITEM(UserDataSubmenu, "EXIT", Main);
+  ADD_MENU_ITEM(UserDataSubmenu, "REONBOARD", Reonboard);
+  ADD_MENU_ITEM(UserDataSubmenu, "CLEAR OUT SOUL", ClearUserData);
+  DISABLE_TIMEOUT(UserDataSubmenu);
 
   // === Self test screen ===
   ADD_MENU_ITEM(SelfTest, "EXIT", Main);
@@ -331,6 +339,17 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
   ADD_MENU_ITEM_WITH_ACTION(SelfTest, "CONFIRM", confirmSelfTest);
   DISABLE_TIMEOUT(SelfTestRunning);
   
+  // === Reonboard screen ===
+  FaceInfoScreen::MenuItemAction confirmReonboard = [] {
+    LOG_INFO("FaceInfoScreenManager.Reonboard.Confirmed", "");
+    (void)system("cd /data/data/com.anki.victor/persistent && rm -f onboarding/onboardingState.json token/token.jwt ../../server_config.json");
+    (void)system("curl 'http://localhost:8080/api/extra/restartvic' &");
+    return ScreenName::Reonboarding;
+  };
+  ADD_MENU_ITEM(Reonboard, "BACK", UserDataSubmenu);
+  ADD_MENU_ITEM_WITH_ACTION(Reonboard, "CONFIRM", confirmReonboard);
+  DISABLE_TIMEOUT(Reonboard);
+
   // Clear User Data menu
   FaceInfoScreen::MenuItemAction confirmClearUserData = [this]() {
     // Write this file to indicate that the data partition should be wiped on reboot
@@ -344,9 +363,9 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
     this->Reboot();
     return ScreenName::Rebooting;
   };
-  ADD_MENU_ITEM(ClearUserData, "EXIT", Main);
+  ADD_MENU_ITEM(ClearUserData, "EXIT", UserDataSubmenu);
   ADD_MENU_ITEM_WITH_ACTION(ClearUserData, "CONFIRM", confirmClearUserData);
-  SET_TIMEOUT(ClearUserDataFail, 2.f, Main);
+  SET_TIMEOUT(ClearUserDataFail, 2.f, UserDataSubmenu);
 
 
   // === Network screen ===
@@ -1986,7 +2005,11 @@ void FaceInfoScreenManager::EnableMirrorModeScreen(bool enable)
 
 void FaceInfoScreenManager::DrawScratch()
 {
-  _currScreen->DrawMenu(*_scratchDrawingImg);
+  if (_currScreen == GetScreen(ScreenName::UserDataSubmenu)) {
+    _currScreen->DrawMenuVertical(*_scratchDrawingImg);
+  } else {
+    _currScreen->DrawMenu(*_scratchDrawingImg);
+  }
 
   // Draw white pixel in top-right corner of main customer support screen
   // to indicate that debug screens are unlocked

--- a/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenTypes.h
+++ b/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenTypes.h
@@ -50,6 +50,9 @@ enum class ScreenName : uint8_t {
   ToggleMute, // Quick animation to show change in microphone mute state
   ToF,
   Kercre123,
+  Reonboard,
+  Reonboarding,
+  UserDataSubmenu,
   
   Count
 };

--- a/animProcess/src/cozmoAnim/robotDataLoader.cpp
+++ b/animProcess/src/cozmoAnim/robotDataLoader.cpp
@@ -186,11 +186,11 @@ void RobotDataLoader::LoadNonConfigData()
                                      _loadingCompleteRatio, _abortLoad);
 
     
-    if(_ankilights()){
-      const auto& fileInfo = animLoader.CollectAnimFiles({kPathToEngineBackpackLightsAnki});
-      LoadBackpackLightAnimations(fileInfo);
-    } else if(_userlights()) {
+    if (_userlights()) {
       const auto& fileInfo = animLoader.CollectAnimFiles({kPathToEngineBackpackLightsUser});
+      LoadBackpackLightAnimations(fileInfo);
+    } else if (_ankilights()) {
+      const auto& fileInfo = animLoader.CollectAnimFiles({kPathToEngineBackpackLightsAnki});
       LoadBackpackLightAnimations(fileInfo);
     } else {
       const auto& fileInfo = animLoader.CollectAnimFiles({kPathToEngineBackpackLightsWireOS});

--- a/engine/components/lightsConfig.h
+++ b/engine/components/lightsConfig.h
@@ -36,7 +36,7 @@ namespace Vector {
     
     if (!initialized) {
       struct stat buffer;
-      value = (stat("/data/data/customBackpackLights/off.json", &buffer) == 0);
+      value = (stat("/data/data/customBackpackLights/cubeSpinner/purple/spinner_purple_celebration.json", &buffer) == 0);
       initialized = true;
     }
     

--- a/project/victor/scripts/victor_deploy_run.sh
+++ b/project/victor/scripts/victor_deploy_run.sh
@@ -3,5 +3,5 @@
 GIT_PROJ_ROOT=`git rev-parse --show-toplevel`
 ${GIT_PROJ_ROOT}/project/victor/scripts/victor_stop.sh &&\
 ${GIT_PROJ_ROOT}/project/victor/scripts/stage.sh &&\
-${GIT_PROJ_ROOT}/project/victor/scripts/deploy.sh &&\
+${GIT_PROJ_ROOT}/project/victor/scripts/deploy.sh -b -i &&\
 ${GIT_PROJ_ROOT}/project/victor/scripts/victor_restart.sh


### PR DESCRIPTION
This PR adds a option to put Vector back into onboarding mode from within CCIS. The previous way to reonboard was to ssh Vector and run `reonboard`. This does that my adding a `DATA/DATA OPTIONS` menu to the main page of CCIS, replacing `CLEAR/CLEAR USER DATA`. In it is the `REONBOARD` and `CLEAR USER DATA` options. I put it into a vertical menu as there's not a easy way to fit it into a horizontal menu on Vector 2.0. When reonboard is selected it does the same as the `reonboard` command, but it also removes the WirePod server config since otherwise you'd need to ssh in to delete that as well.

This PR also changes the priority of loading backpack lights so that custom backpack lights have the highest priority.