### PR TITLE
Fix displaying monochrome on Vector 2.0

### DIFF
--- a/animProcess/src/cozmoAnim/animation/animationStreamer.cpp
+++ b/animProcess/src/cozmoAnim/animation/animationStreamer.cpp
@@ -669,7 +669,7 @@ namespace Anim {
     }
     assert(destI == kExpectedNumPixels * (1+msg.chunkIndex));
 
-    if (_faceImageChunksReceivedBitMask == kAllFaceImageChunksReceivedMask) {
+    if (_faceImageChunksReceivedBitMask == IsXray() ? kAllFaceImageGrayscaleChunksReceivedMaskFor15Chunks : kAllFaceImageGrayscaleChunksReceivedMaskFor15Chunks) {
       auto* img = new Vision::ImageRGBA(FACE_DISPLAY_HEIGHT, FACE_DISPLAY_WIDTH);
       img->SetFromGray(_faceImageGrayscale);
       auto handle = std::make_shared<Vision::SpriteWrapper>(img);
@@ -707,7 +707,7 @@ namespace Anim {
     uint8_t* imageData_i = _faceImageGrayscale.GetDataPointer();
     std::copy_n(msg.faceData, numPixels, imageData_i + (msg.chunkIndex * kMaxNumPixelsPerChunk) );
 
-    if (_faceImageGrayscaleChunksReceivedBitMask == kAllFaceImageGrayscaleChunksReceivedMask) {
+    if (_faceImageGrayscaleChunksReceivedBitMask == IsXray() ? kAllFaceImageGrayscaleChunksReceivedMaskFor15Chunks : kAllFaceImageGrayscaleChunksReceivedMaskFor15Chunks) {
       auto* img = new Vision::ImageRGBA(FACE_DISPLAY_HEIGHT, FACE_DISPLAY_WIDTH);
       img->SetFromGray(_faceImageGrayscale);
       auto handle = std::make_shared<Vision::SpriteWrapper>(img);
@@ -718,6 +718,8 @@ namespace Anim {
       _wasAnimationInterruptedWithNothing = true;
       _faceImageGrayscaleId = 0;
       _faceImageGrayscaleChunksReceivedBitMask = 0;
+    } else {
+      LOG_INFO("AnimationStreamer.Process_displayFaceImageChunk", "Not enough face image chunks, not displaying image");
     }
   }
 

--- a/animProcess/src/cozmoAnim/animation/animationStreamer.h
+++ b/animProcess/src/cozmoAnim/animation/animationStreamer.h
@@ -289,7 +289,8 @@ namespace Anim {
     // Grayscale images
     u32                 _faceImageGrayscaleId                    = 0;      // Used only for tracking chunks of the same image as they are received
     u32                 _faceImageGrayscaleChunksReceivedBitMask = 0;
-    const u32           kAllFaceImageGrayscaleChunksReceivedMask = 0x7fff; // 15 bits for 15 expected chunks (FACE_DISPLAY_NUM_PIXELS / 1200 pixels_per_msg ~= 15)
+    const u32           kAllFaceImageGrayscaleChunksReceivedMaskFor15Chunks = 0x7fff; // 15 bits for 15 expected chunks (FACE_DISPLAY_NUM_PIXELS / 1200 pixels_per_msg ~= 15)
+    const u32           kAllFaceImageGrayscaleChunksReceivedMaskFor11Chunks = 0x7ff;  // 11 bits for 11 expected chunks (FACE_DISPLAY_NUM_PIXELS / 1200 pixels_per_msg ~= 11)
 
     // RGB images
     Vision::ImageRGB565 _faceImageRGB565;


### PR DESCRIPTION
This was something that was not fone by ddl when they added 2.0 support, they did this for RGB though. This caused stuff like the IMU menu selector test and snake to not show up on Vector 2.0, and likely other small things would have broken too. This also meant that if someone wanted to display some text on Vector's screen using the way snake or the IMU selector did it'd just not display. Now it can.